### PR TITLE
Fix code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -94,9 +94,9 @@ app.post("/convert", (req, res) => {
 // Download route
 app.get("/download/:fileName", (req, res) => {
   const { fileName } = req.params;
-  const filePath = path.join(TMP_DIR, fileName);
+  const filePath = path.resolve(TMP_DIR, fileName);
 
-  if (!fs.existsSync(filePath)) {
+  if (!filePath.startsWith(TMP_DIR) || !fs.existsSync(filePath)) {
     return res.status(404).json({ success: false, error: "File not found." });
   }
 


### PR DESCRIPTION
Fixes [https://github.com/Screepho/screepho-media-tools/security/code-scanning/3](https://github.com/Screepho/screepho-media-tools/security/code-scanning/3)

To fix the problem, we need to ensure that the constructed file path is contained within the `TMP_DIR` directory. We can achieve this by normalizing the path using `path.resolve` and then checking that the normalized path starts with the `TMP_DIR` path. This will prevent path traversal attacks by ensuring that the file path does not escape the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
