### PR TITLE
Fix code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "express": "^4.21.1",
     "ffmpeg-static": "^5.2.0",
     "slugify": "^1.6.6",
-    "uuid": "^11.0.3"
+    "uuid": "^11.0.3",
+    "express-rate-limit": "^7.4.1"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,6 +4,7 @@ const { exec } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { v4: uuidv4 } = require("uuid");
+const rateLimit = require("express-rate-limit");
 
 const app = express();
 app.use(cors());
@@ -16,8 +17,14 @@ if (!fs.existsSync(TMP_DIR)) {
 
 const PORT = process.env.PORT || 5000;
 
+// Rate limiter: maximum of 100 requests per 15 minutes
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
 // Convert route
-app.post("/convert", (req, res) => {
+app.post("/convert", limiter, (req, res) => {
   const { url, format } = req.body;
 
   if (!url || !format) {


### PR DESCRIPTION
Fixes [https://github.com/Screepho/screepho-media-tools/security/code-scanning/6](https://github.com/Screepho/screepho-media-tools/security/code-scanning/6)

To fix the problem, we should introduce rate limiting to the Express application. The `express-rate-limit` package is a well-known middleware for this purpose. We will set up a rate limiter that restricts the number of requests a client can make to the `/convert` route within a specified time window. This will help mitigate the risk of DoS attacks by limiting the rate at which requests are accepted.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `backend/server.js` file.
3. Configure the rate limiter with appropriate settings (e.g., maximum number of requests per time window).
4. Apply the rate limiter to the `/convert` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
